### PR TITLE
[0.2] Update to sync ingress services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /trash.lock
 /.idea
 /.gopath
+/k8s-net-attach-def-controller


### PR DESCRIPTION
Fix https://github.com/cnrancher/pandaria/issues/3225

## Manual Test

编辑 Ingress 负载均衡的 “启用/关闭扁平网络负载” 选项，Ingress Endpoints 会在编辑后一段时间内（不超过 30 秒）发生变化，[参考此处视频](https://github.com/cnrancher/k8s-net-attach-def-controller/assets/41445339/aa567eea-08a1-4b7b-90f9-8d1b956aeca3)。
