### PR TITLE
[0.2] Update to sync ingress services

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -574,16 +574,6 @@ func (c *NetworkController) handleEndpointSliceEvent(obj interface{}) {
 }
 
 func (c *NetworkController) needToSyncService(serviceName string) bool {
-	if c.needToUpdateEndpointSlice {
-		// If k8s version > 1.20 and supports discovery.k8s.io/v1,
-		// Only sync the macvlan service.
-		// This controller will update the Endpoint Slice by using discovery.k8s.io/v1 API.
-		return strings.HasSuffix(serviceName, svcSuffixMacvlan)
-	}
-
-	// If k8s version <= 1.20 and does not support discover.k8s.io/v1,
-	// Sync the macvlan service and rancher created ingress services.
-	// This controller will update the ingress endpoints directly.
 	return strings.HasSuffix(serviceName, svcSuffixMacvlan) || strings.HasPrefix(serviceName, svcPrefixIngress)
 }
 


### PR DESCRIPTION
Related issue:
- https://github.com/cnrancher/pandaria/issues/3234#issuecomment-1926519483

若 K8s 集群支持 EndpointSlice (>= 1.22)，依旧需要同步名为 `ingress-` 的 Ingress Service，否则即使启用扁平网络负载，Endpoint IP 依旧没有被修改为 Macvlan IP。 